### PR TITLE
Fix tag deletion to reference vector docstore

### DIFF
--- a/src/cogniweave/vectorstores/tags.py
+++ b/src/cogniweave/vectorstores/tags.py
@@ -902,7 +902,7 @@ class TagsVector(Generic[MetaType]):
             raise ValueError("No ids provided to delete.")
         doc_ids: set[str] = set()
         for id_ in ids:
-            if isinstance(tag_doc := self.metastore.search(id_), Document):
+            if isinstance(tag_doc := self.vector.docstore.search(id_), Document):
                 doc_ids.update(cast("TagDucumentId", tag_doc.metadata)["file_ids"])
         for doc_id in doc_ids:
             if not isinstance(doc := self.metastore.search(doc_id), str):


### PR DESCRIPTION
## Summary
- fix `delete_tags` to search tag docs in `vector.docstore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: dotenv, cogniweave)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b65e46c832fb8d6cc8fd4afd336