### PR TITLE
Refactor session grouping

### DIFF
--- a/tests/grouping.py
+++ b/tests/grouping.py
@@ -1,6 +1,7 @@
 import asyncio
 import math
 import time
+import uuid
 from collections import defaultdict, deque
 from enum import Enum
 from typing import Self
@@ -60,7 +61,7 @@ class TimeWheel:
 
 
 class WeightedAverageCalculator:
-    """compute exponentially weighted moving average of timestamps."""
+    """Compute exponentially weighted moving average of intervals."""
 
     _cached_weights: dict
 
@@ -68,27 +69,22 @@ class WeightedAverageCalculator:
         self._cached_weights = {}
         self.adaptive_strength = adaptive_strength
 
-    def compute(self, timestamps: deque[float], smoothing_factor: float = 0.9) -> float:
-        """
-        compute ewma of time intervals.
-
-        timestamps: deque of timestamps (must be sorted ascending)
-        smoothing_factor: controls decay of older intervals
-        """
-        num_intervals = len(timestamps) - 1
-        if num_intervals <= 0:
+    def compute(self, intervals: deque[float], smoothing_factor: float = 0.9) -> float:
+        """Return EWMA of `intervals`."""
+        num = len(intervals)
+        if num <= 0:
             return 100.0
 
-        if num_intervals not in self._cached_weights:
+        if num not in self._cached_weights:
             weights = np.exp(
-                -smoothing_factor * np.linspace(0, num_intervals - 1, num_intervals)[::-1]
+                -smoothing_factor * np.linspace(0, num - 1, num)[::-1]
             )
-            self._cached_weights[num_intervals] = weights
+            self._cached_weights[num] = weights
 
-        weights = self._cached_weights[num_intervals]
-        intervals = np.diff(list(timestamps))
-        weighted_avg = np.dot(weights, intervals) / np.sum(weights)
-        return max(weighted_avg, 1e-9)
+        weights = self._cached_weights[num]
+        arr = np.array(intervals)
+        weighted_avg = np.dot(weights, arr) / np.sum(weights)
+        return max(float(weighted_avg), 1e-9)
 
 
 class DynamicDecayCalculator:
@@ -183,32 +179,36 @@ class DensityCalculator:
 
 
 class AsyncConditionDensityManager(BaseModel):
-    """manage per-user density with adaptive session segmentation."""
+    """Manage density weights with adaptive segmentation."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    window_size: int = 20
-    decay_factor: float = 0.1
-    scaling_factor: int = 10
-    avg_smoothing_factor: float = 0.9
-    ema_alpha: float = 0.8
+    # exposed configuration
     time_window: float | None = None
     density_strategy: DensityStrategy = DensityStrategy.AUTO
-    adaptive_strength: float = 0.9
-    auto_threshold_low: float = 4
-    auto_threshold_high: float = 10
-    segment_factor: float = 2.0
-    segment_min: float = 60.0
-    segment_max: float = 3600.0
-    std_multiplier: float = 1.0
-    min_messages_per_session: int = 2
+
+    # internal constants
+    _WINDOW_SIZE: int = 20
+    _DECAY_FACTOR: float = 0.1
+    _SCALING_FACTOR: int = 10
+    _AVG_SMOOTHING: float = 0.9
+    _EMA_ALPHA: float = 0.8
+    _ADAPTIVE_STRENGTH: float = 0.9
+    _AUTO_LOW: float = 4.0
+    _AUTO_HIGH: float = 10.0
+    _SEGMENT_FACTOR: float = 2.0
+    _SEGMENT_MIN: float = 60.0
+    _SEGMENT_MAX: float = 3600.0
+    _STD_MULTIPLIER: float = 1.0
+    _MIN_MSGS: int = 2
 
     # non-init internal state
-    condition_timestamps: dict[str, TimeWheel] = {}
-    condition_weights: dict[str, float] = {}
-    _last_timestamp_per_key: dict[str, float] = {}
-    _intervals_per_key: dict[str, deque[float]] = {}
-    _message_count_per_key: dict[str, int] = {}
+    session_timestamps: dict[str, TimeWheel] = {}
+    session_weights: dict[str, float] = {}
+    _last_timestamp: dict[str, float] = {}
+    _intervals: dict[str, deque[float]] = {}
+    _message_count: dict[str, int] = {}
+    _segment_id_per_key: dict[str, str] = {}
     density_calculator: DensityCalculator | None = None
     weighted_avg_calc: WeightedAverageCalculator | None = None
     lock: asyncio.Lock | None = None
@@ -216,21 +216,21 @@ class AsyncConditionDensityManager(BaseModel):
 
     @model_validator(mode="after")
     def build_state(self) -> Self:
-        self.condition_timestamps = defaultdict(
-            lambda: TimeWheel(self.window_size, self.time_window or 0)
+        self.session_timestamps = defaultdict(
+            lambda: TimeWheel(self._WINDOW_SIZE, self.time_window or 0)
         )
-        self.condition_weights = defaultdict(float)
-        self._last_timestamp_per_key = {}
-        self._intervals_per_key = defaultdict(lambda: deque(maxlen=5))
-        self._message_count_per_key = defaultdict(int)
+        self.session_weights = defaultdict(float)
+        self._last_timestamp = {}
+        self._intervals = defaultdict(lambda: deque(maxlen=5))
+        self._message_count = defaultdict(int)
         self.density_calculator = DensityCalculator(
             strategy=self.density_strategy,
-            ema_alpha=self.ema_alpha,
-            decay_factor=self.decay_factor,
-            auto_threshold_low=self.auto_threshold_low,
-            auto_threshold_high=self.auto_threshold_high,
+            ema_alpha=self._EMA_ALPHA,
+            decay_factor=self._DECAY_FACTOR,
+            auto_threshold_low=self._AUTO_LOW,
+            auto_threshold_high=self._AUTO_HIGH,
         )
-        self.weighted_avg_calc = WeightedAverageCalculator(self.adaptive_strength)
+        self.weighted_avg_calc = WeightedAverageCalculator(self._ADAPTIVE_STRENGTH)
         self.lock = asyncio.Lock()
         if self.time_window:
             self.prune_task = asyncio.create_task(self.auto_prune(interval=60.0))
@@ -243,74 +243,76 @@ class AsyncConditionDensityManager(BaseModel):
             await asyncio.sleep(interval)
             async with self.lock:
                 now = time.time()
-                for key in list(self.condition_timestamps.keys()):
-                    self.condition_timestamps[key].prune(now)
-                    if not self.condition_timestamps[key].get_all():
-                        del self.condition_timestamps[key]
-                        del self.condition_weights[key]
-                        self._last_timestamp_per_key.pop(key, None)
-                        self._intervals_per_key.pop(key, None)
-                        self._message_count_per_key.pop(key, None)
+                for key in list(self.session_timestamps.keys()):
+                    self.session_timestamps[key].prune(now)
+                    if not self.session_timestamps[key].get_all():
+                        del self.session_timestamps[key]
+                        del self.session_weights[key]
+                        self._last_timestamp.pop(key, None)
+                        self._intervals.pop(key, None)
+                        self._message_count.pop(key, None)
 
     async def update_condition_density(
-        self, condition_key: str, current_time: float | None = None
-    ) -> None:
-        """
-        process a new message event for a user.
+        self, session_id: str, current_time: float | None = None
+    ) -> str:
+        """Update density for a session.
 
-        condition_key: unique identifier for the user or session
-        current_time: timestamp of the new message
+        Args:
+            session_id: Identifier of the conversation.
+            current_time: Unix timestamp of the new event.
+
+        Returns:
+            Current segment identifier.
         """
         assert self.lock
         assert self.weighted_avg_calc
         assert self.density_calculator
 
         async with self.lock:
-            now = current_time or time.time()
-            last_ts = self._last_timestamp_per_key.get(condition_key)
+            now = float(current_time) if current_time is not None else time.time()
+            last_ts = self._last_timestamp.get(session_id)
+
+            segment_id = self._segment_id_per_key.get(session_id)
+            if segment_id is None:
+                segment_id = uuid.uuid4().hex
+                self._segment_id_per_key[session_id] = segment_id
 
             if last_ts is not None:
                 delta = now - last_ts
-                intervals = self._intervals_per_key[condition_key]
+                intervals = self._intervals[session_id]
                 intervals.append(delta)
 
-                # reconstruct fake timestamps for ewma computation
-                fake_timestamps = deque()
-                cur = last_ts
-                fake_timestamps.append(cur)
-                for d in reversed(intervals):
-                    cur -= d
-                    fake_timestamps.appendleft(cur)
-
                 avg_interval = self.weighted_avg_calc.compute(
-                    fake_timestamps, self.avg_smoothing_factor
+                    intervals, self._AVG_SMOOTHING
                 )
                 std_dev = float(np.std(list(intervals))) if len(intervals) > 1 else 0.0
 
                 # compute dynamic threshold with std multiplier
-                raw_threshold = self.segment_factor * avg_interval + self.std_multiplier * std_dev
-                dynamic_threshold = min(max(raw_threshold, self.segment_min), self.segment_max)
+                raw_threshold = self._SEGMENT_FACTOR * avg_interval + self._STD_MULTIPLIER * std_dev
+                dynamic_threshold = min(max(raw_threshold, self._SEGMENT_MIN), self._SEGMENT_MAX)
 
-                msg_count = self._message_count_per_key.get(condition_key, 0)
-                if delta > dynamic_threshold and msg_count >= self.min_messages_per_session:
+                msg_count = self._message_count.get(session_id, 0)
+                if delta > dynamic_threshold and msg_count >= self._MIN_MSGS:
                     # new session: reset state
-                    self.condition_timestamps[condition_key] = TimeWheel(
-                        self.window_size, self.time_window or 0
+                    self.session_timestamps[session_id] = TimeWheel(
+                        self._WINDOW_SIZE, self.time_window or 0
                     )
-                    self.condition_weights[condition_key] = 0.0
-                    self._intervals_per_key[condition_key].clear()
-                    self._message_count_per_key[condition_key] = 0
+                    self.session_weights[session_id] = 0.0
+                    self._intervals[session_id].clear()
+                    self._message_count[session_id] = 0
+                    segment_id = uuid.uuid4().hex
+                    self._segment_id_per_key[session_id] = segment_id
 
             else:
                 # first message for this user
                 avg_interval = 100.0  # fallback for first message
 
             # update last timestamp and increment message count
-            self._last_timestamp_per_key[condition_key] = now
-            self._message_count_per_key[condition_key] += 1
+            self._last_timestamp[session_id] = now
+            self._message_count[session_id] += 1
 
             # add current timestamp to time wheel
-            tw = self.condition_timestamps[condition_key]
+            tw = self.session_timestamps[session_id]
             tw.add(now)
             if self.time_window:
                 tw.prune(now)
@@ -319,33 +321,29 @@ class AsyncConditionDensityManager(BaseModel):
             if len(timestamps) < 2:
                 avg_interval_calc = 100.0
             else:
-                avg_interval_calc = self.weighted_avg_calc.compute(
-                    timestamps, self.avg_smoothing_factor
-                )
+                diffs = np.diff(list(timestamps))
+                avg_interval_calc = float(np.mean(diffs)) if len(diffs) else 100.0
 
             growth = Sigmoid.f(avg_interval_calc, 0.275, 0.61, 8.6, 0.3)
             decay = Sigmoid.f(avg_interval_calc, 0.045, 0.155, 10, 0.3)
 
-            growth = 0.9 * growth + 0.1 * self.condition_weights[condition_key]
+            growth = 0.9 * growth + 0.1 * self.session_weights[session_id]
             decay = max(0.05, 0.9 * decay + 0.1 * (1 / (avg_interval_calc + 1)))
 
             density_increment = growth / (avg_interval_calc + 1)
             decay_factor = math.exp(-decay * avg_interval_calc)
 
             new_weight = self.density_calculator.calculate(
-                prev_weight=self.condition_weights[condition_key],
+                prev_weight=self.session_weights[session_id],
                 density_increment=density_increment,
                 decay_factor=decay_factor,
                 avg_interval=avg_interval_calc,
             )
-            self.condition_weights[condition_key] = new_weight
+            self.session_weights[session_id] = new_weight
 
-    def get_density_weight(self, condition_key: str) -> float:
-        """
-        retrieve current density weight for a user.
+            return segment_id
 
-        condition_key: unique identifier for the user
-        returns: density weight mapped to [-0.2, 0.5]
-        """
-        w = max(1e-9, self.condition_weights.get(condition_key, 1e-9) * 10)
-        return 0.05 * max(-4, math.log(self.scaling_factor * w))
+    def get_density_weight(self, session_id: str) -> float:
+        """Return current density weight for a session."""
+        w = max(1e-9, self.session_weights.get(session_id, 1e-9) * 10)
+        return 0.05 * max(-4, math.log(self._SCALING_FACTOR * w))


### PR DESCRIPTION
## Summary
- rework density manager to track sessions by id
- generate UUID when session boundaries change
- simplify parameter surface and calculations
- return segment id from `update_condition_density`
- minor code cleanup and docstring updates

## Testing
- `ruff check tests/grouping.py`
- `pytest -q` *(fails: ModuleNotFoundError for langchain_core, dotenv, openai)*

------
https://chatgpt.com/codex/tasks/task_e_683fd4579be4832f8d513e5c7ae9c9bc