### PR TITLE
Extend HistoryStore features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "langchain",
     "langchain_openai",
     "langchain-community==0.3.24",
+    "sqlalchemy>=2.0",
+    "aiosqlite",
     "python-dotenv",
     "httpx[socks]",
     "langgraph",

--- a/tests/test_history_store_attributes.py
+++ b/tests/test_history_store_attributes.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage
+
+from cogniweave.core.database import ChatBlock
+from cogniweave.core.database.history import HistoryStore
+
+
+def test_block_attributes(tmp_path: Path) -> None:
+    store = HistoryStore(db_url=f"sqlite:///{tmp_path}/attrs.sqlite")
+    cfg = {"configurable": {"session_id": "attr", "session_timestamp": 1.0}}
+    store.invoke({"message": HumanMessage("hello"), "timestamp": 1.1}, config=cfg)
+
+    with store._session_local() as session:
+        block = session.query(ChatBlock).filter_by(context_id="attr").first()
+        assert block is not None
+        block_id = block.id
+
+    store.invoke({"block_attribute": {"type": "summary", "value": {"text": "hello"}}}, config=cfg)
+    attrs = store.get_block_attributes(block_id)
+    assert len(attrs) == 1
+    assert attrs[0].type == "summary"
+    assert attrs[0].value == {"text": "hello"}


### PR DESCRIPTION
## Summary
- support `ChatBlockAttribute` in HistoryStore
- test storing and retrieving attributes
- add async SQLAlchemy support and drop `to_thread`
- add `sqlalchemy` and `aiosqlite` to deps
- allow adding block attributes via `HistoryStore.invoke`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy', 'dotenv', 'langchain_core', and others)*


------
https://chatgpt.com/codex/tasks/task_e_684aa6eef0b8832fa30a2eb6a5744a0a