### PR TITLE
Rename history store keys

### DIFF
--- a/src/cogniweave/historystore/models.py
+++ b/src/cogniweave/historystore/models.py
@@ -38,7 +38,7 @@ class ChatBlock(Base):
     __tablename__ = "chat_blocks"
 
     context_id: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
-    user_id: Mapped[int] = mapped_column(
+    session_id: Mapped[int] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -58,13 +58,15 @@ class ChatBlock(Base):
         lazy="selectin",
     )
 
-    __table_args__ = (Index("idx_chat_blocks_user_start", "user_id", "start_time"),)
+    __table_args__ = (
+        Index("idx_chat_blocks_session_start", "session_id", "start_time"),
+    )
 
     @override
     def __repr__(self) -> str:
         return (
             f"<ChatBlock(id={self.id}, context_id={self.context_id!r}, "
-            f"user_id={self.user_id}, start_time={self.start_time})>"
+            f"session_id={self.session_id}, start_time={self.start_time})>"
         )
 
 

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -14,7 +14,7 @@ def test_history_store_persistence_and_retrieval(tmp_path: Path) -> None:
     store = HistoryStore(db_url=f"sqlite:///{tmp_path}/test.sqlite")
 
     cfg = cast(
-        "RunnableConfig", {"configurable": {"session_id": "s1", "session_timestamp": 1000.0}}
+        "RunnableConfig", {"configurable": {"block_id": "s1", "block_timestamp": 1000.0}}
     )
     msgs = ["hi", "how", "are", "you"]
     for i, text in enumerate(msgs):
@@ -33,7 +33,7 @@ def test_history_store_persistence_and_retrieval(tmp_path: Path) -> None:
 async def test_history_store_async(tmp_path: Path) -> None:
     store = HistoryStore(db_url=f"sqlite:///{tmp_path}/async.sqlite")
 
-    cfg = cast("RunnableConfig", {"configurable": {"session_id": "s2", "session_timestamp": 50.0}})
+    cfg = cast("RunnableConfig", {"configurable": {"block_id": "s2", "block_timestamp": 50.0}})
     await store.ainvoke({"message": HumanMessage("hello"), "timestamp": 51.0}, config=cfg)
     await store.ainvoke({"message": HumanMessage("world"), "timestamp": 52.0}, config=cfg)
 
@@ -43,7 +43,7 @@ async def test_history_store_async(tmp_path: Path) -> None:
 
 def test_block_attributes(tmp_path: Path) -> None:
     store = HistoryStore(db_url=f"sqlite:///{tmp_path}/attrs.sqlite")
-    cfg = cast("RunnableConfig", {"configurable": {"session_id": "attr", "session_timestamp": 1.0}})
+    cfg = cast("RunnableConfig", {"configurable": {"block_id": "attr", "block_timestamp": 1.0}})
     store.invoke({"message": HumanMessage("hello"), "timestamp": 1.1}, config=cfg)
 
     store.invoke({"block_attribute": {"type": "summary", "value": {"text": "hello"}}}, config=cfg)
@@ -55,7 +55,7 @@ def test_block_attributes(tmp_path: Path) -> None:
 
 async def test_block_attributes_async(tmp_path: Path) -> None:
     store = HistoryStore(db_url=f"sqlite:///{tmp_path}/attrs.sqlite")
-    cfg = cast("RunnableConfig", {"configurable": {"session_id": "attr", "session_timestamp": 1.0}})
+    cfg = cast("RunnableConfig", {"configurable": {"block_id": "attr", "block_timestamp": 1.0}})
     store.invoke({"message": HumanMessage("hello"), "timestamp": 1.1}, config=cfg)
 
     await store.ainvoke(


### PR DESCRIPTION
## Summary
- rename user_id to session_id in models
- rename session_id to block_id and session_timestamp to block_timestamp
- update HistoryStore accordingly
- keep tests in sync with new key names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684ad4b1b76c832f9f9b665d0e23358a