### PR TITLE
Fix multi-block history ordering

### DIFF
--- a/src/cogniweave/historystore/base.py
+++ b/src/cogniweave/historystore/base.py
@@ -533,10 +533,7 @@ class BaseHistoryStore(BaseModel):
             list[BaseMessage]: Combined list of messages from all blocks,
                 in chronological order.
         """
-        messages: list[BaseMessage] = []
-        for sid in sorted(block_ids):
-            messages.extend(self.get_history(sid))
-        return messages
+        return [msg for msg, _ in self.get_histories_with_timestamps(block_ids)]
 
     async def aget_histories(self, block_ids: list[str]) -> list[BaseMessage]:
         """Async version of get_histories.
@@ -548,10 +545,8 @@ class BaseHistoryStore(BaseModel):
             list[BaseMessage]: Combined list of messages from all blocks,
                 in chronological order.
         """
-        messages: list[BaseMessage] = []
-        for sid in sorted(block_ids):
-            messages.extend(await self.aget_history(sid))
-        return messages
+        pairs = await self.aget_histories_with_timestamps(block_ids)
+        return [msg for msg, _ in pairs]
 
     def get_block_attributes(
         self, block_id: str, *, types: list[str] | None = None

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -359,6 +359,27 @@ def test_histories_with_multiple_blocks_order(tmp_path: Path) -> None:
     ]
 
 
+def test_histories_with_multiple_blocks_order_no_ts(tmp_path: Path) -> None:
+    """`get_histories` preserves chronological ordering across blocks."""
+
+    store = BaseHistoryStore(db_url=f"sqlite:///{tmp_path}/multi_no_ts.sqlite")
+
+    store.add_messages([(HumanMessage("b1-1"), 1.1)], block_id="b1", block_ts=1.0)
+    store.add_messages([(HumanMessage("b1-2"), 1.3)], block_id="b1", block_ts=1.0)
+    store.add_messages([(HumanMessage("b2-1"), 0.6)], block_id="b2", block_ts=0.5)
+    store.add_messages([(HumanMessage("b2-2"), 1.2)], block_id="b2", block_ts=0.5)
+    store.add_messages([(HumanMessage("b2-3"), 1.4)], block_id="b2", block_ts=0.5)
+
+    result = store.get_histories(["b2", "b1"])
+    assert [m.content for m in result] == [
+        "b2-1",
+        "b1-1",
+        "b2-2",
+        "b1-2",
+        "b2-3",
+    ]
+
+
 async def test_async_histories_with_multiple_blocks_order(tmp_path: Path) -> None:
     """Async variant of multi-block history ordering."""
 
@@ -372,6 +393,27 @@ async def test_async_histories_with_multiple_blocks_order(tmp_path: Path) -> Non
 
     result = await store.aget_histories_with_timestamps(["b2", "b1"])
     assert [m.content for m, _ in result] == [
+        "b2-1",
+        "b1-1",
+        "b2-2",
+        "b1-2",
+        "b2-3",
+    ]
+
+
+async def test_async_histories_with_multiple_blocks_order_no_ts(tmp_path: Path) -> None:
+    """Async version of `get_histories` ordering test."""
+
+    store = BaseHistoryStore(db_url=f"sqlite:///{tmp_path}/multi_async_no_ts.sqlite")
+
+    await store.aadd_messages([(HumanMessage("b1-1"), 1.1)], block_id="b1", block_ts=1.0)
+    await store.aadd_messages([(HumanMessage("b1-2"), 1.3)], block_id="b1", block_ts=1.0)
+    await store.aadd_messages([(HumanMessage("b2-1"), 0.6)], block_id="b2", block_ts=0.5)
+    await store.aadd_messages([(HumanMessage("b2-2"), 1.2)], block_id="b2", block_ts=0.5)
+    await store.aadd_messages([(HumanMessage("b2-3"), 1.4)], block_id="b2", block_ts=0.5)
+
+    result = await store.aget_histories(["b2", "b1"])
+    assert [m.content for m in result] == [
         "b2-1",
         "b1-1",
         "b2-2",


### PR DESCRIPTION
## Summary
- ensure `get_histories` and `aget_histories` use timestamp ordered retrieval
- add regression tests validating ordering without timestamps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d8aa03d40832f93e1487d6460f975