### PR TITLE
Add user attribute support

### DIFF
--- a/src/cogniweave/history_store/__init__.py
+++ b/src/cogniweave/history_store/__init__.py
@@ -11,6 +11,7 @@ from .models import (
     ChatBlockAttribute,
     ChatMessage,
     User,
+    UserAttribute,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "ChatBlockAttribute",
     "ChatMessage",
     "User",
+    "UserAttribute",
 ]

--- a/src/cogniweave/history_store/models.py
+++ b/src/cogniweave/history_store/models.py
@@ -25,6 +25,11 @@ class User(Base):
         order_by="ChatBlock.timestamp",
         lazy="selectin",
     )
+    attributes: Mapped[list[UserAttribute]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
     __table_args__ = (Index("idx_user_name", "name"),)
 
@@ -118,3 +123,25 @@ class ChatBlockAttribute(Base):
     @override
     def __repr__(self) -> str:
         return f"<ChatBlockAttribute(id={self.id}, block_id={self.block_id}, type={self.type!r})>"
+
+
+class UserAttribute(Base):
+    """Auxiliary data for a User."""
+
+    __tablename__ = "user_attributes"
+
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    type: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    value: Mapped[Any] = mapped_column(JSON, nullable=False)
+
+    user: Mapped[User] = relationship("User", back_populates="attributes", lazy="joined")
+
+    __table_args__ = (Index("idx_user_attributes_user_type", "user_id", "type"),)
+
+    @override
+    def __repr__(self) -> str:
+        return f"<UserAttribute(id={self.id}, user_id={self.user_id}, type={self.type!r})>"


### PR DESCRIPTION
## Summary
- add `UserAttribute` model for storing user-level attributes
- export new model from history store package
- implement `add_user_attributes` and `aadd_user_attributes` for saving/updating user attributes
- test new synchronous and async user attribute APIs

## Testing
- `ruff check --fix src/cogniweave/history_store/models.py src/cogniweave/history_store/__init__.py src/cogniweave/history_store/base.py tests/test_history_store.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_6856ca8f6c84832fb3d94c62c8a03f44