### PR TITLE
Fix imports in core prompt_values

### DIFF
--- a/src/cogniweave/core/prompt_values/end_detector.py
+++ b/src/cogniweave/core/prompt_values/end_detector.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from cogniweave.prompt_values.base import MultilingualSystemPromptValue
 
-from .values.end_detector import (
+from cogniweave.core.prompt_values.values.end_detector import (
     END_DETECTOR_PROMPT_EN,
     END_DETECTOR_PROMPT_ZH,
 )

--- a/src/cogniweave/core/prompt_values/long_memory.py
+++ b/src/cogniweave/core/prompt_values/long_memory.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from cogniweave.prompt_values.base import MultilingualSystemPromptValue
 
-from .values.long_memory import (
+from cogniweave.core.prompt_values.values.long_memory import (
     LONG_TERM_MEMORY_EXTRACT_EN,
     LONG_TERM_MEMORY_EXTRACT_ZH,
     LONG_TERM_MEMORY_UPDATE_EN,

--- a/src/cogniweave/core/prompt_values/summary.py
+++ b/src/cogniweave/core/prompt_values/summary.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from cogniweave.prompt_values.base import MultilingualSystemPromptValue
 
-from .values.summary import (
+from cogniweave.core.prompt_values.values.summary import (
     SHORT_TERM_MEMORY_SUMMARY_EN,
     SHORT_TERM_MEMORY_SUMMARY_ZH,
 )

--- a/src/cogniweave/core/prompt_values/tagger.py
+++ b/src/cogniweave/core/prompt_values/tagger.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 from cogniweave.prompt_values.base import MultilingualSystemPromptValue
 
-from .values.tagger import (
+from cogniweave.core.prompt_values.values.tagger import (
     SHORT_TERM_MEMORY_TAGS_EN,
     SHORT_TERM_MEMORY_TAGS_ZH,
 )


### PR DESCRIPTION
## Summary
- update internal imports to use package path `cogniweave.core.prompt_values.values`
- keep tests in place

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_685f997b8cbc832fa5705ab9c6e9c88e