### PR TITLE
Introduce quickstart builder and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# CogniWeaveAgent
+# CogniWeave
+
+CogniWeave is an experimental agent framework.  The repository includes
+utilities and runnable components used in the tests.  A small helper
+module ``cogniweave.quickstart`` exposes functions that simplify
+building the demonstration pipeline used in ``tests/runnables/demo.py``.
+
+## Quick demo
+
+Install the project dependencies (see ``pyproject.toml``). Then run the
+CLI to start an interactive session:
+
+```bash
+python scripts/cli.py demo
+```
+
+You can optionally specify a custom session identifier which controls
+the history database and vector index used:
+
+```bash
+python scripts/cli.py demo my_session
+```
+
+The ``cogniweave.quickstart`` module also provides utilities to programmatically
+construct the demo pipeline:
+
+```python
+from cogniweave.quickstart import build_pipeline
+
+pipeline = build_pipeline(session_id="my_session")
+```

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import textwrap
+import warnings
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from langchain_core.messages import AIMessage, HumanMessage
+from rich.align import Align
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+
+from cogniweave.quickstart import build_pipeline, DEF_DB
+from cogniweave.core.history_stores import BaseHistoryStore as HistoryStore
+
+warnings.filterwarnings("ignore")
+
+
+def _get_input(prompt: str = "> ") -> str | None:
+    console = Console()
+    console.print(f"{prompt}", style="bold blink bright_cyan", end="")
+    try:
+        input_msg = input()
+    except (KeyboardInterrupt, EOFError):
+        sys.stdout.write("\033[K")
+        return None
+
+    if input_msg.strip().lower() == "exit":
+        return None
+
+    term_width = shutil.get_terminal_size().columns
+    wrapped = textwrap.wrap(prompt + input_msg, width=term_width)
+    sys.stdout.write("\033[F" * len(wrapped))
+    return input_msg
+
+
+def _print_input(console: Console, message: str) -> None:
+    bubble = Panel(message, style="bold #63bbd0", expand=False)
+    console.print(Align.right(bubble))
+
+
+def _print_output(console: Console, message: str) -> None:
+    bubble = Panel(Markdown(message), style="#83cbac", expand=False)
+    console.print(Align.left(bubble))
+
+
+def demo(session_id: str) -> None:
+    pipeline = build_pipeline(session_id=session_id)
+    history_store = HistoryStore(db_url=f"sqlite:///{DEF_DB}")
+    console = Console()
+
+    nearly_history = history_store.get_session_history(session_id, limit=10)
+    for hist in nearly_history:
+        if isinstance(hist, HumanMessage):
+            _print_input(console, str(hist.content))
+        elif isinstance(hist, AIMessage):
+            _print_output(console, str(hist.content))
+
+    while True:
+        input_msg = _get_input()
+        if not input_msg:
+            break
+
+        _print_input(console, input_msg)
+        chunks: Iterator[dict[str, Any]] = pipeline.stream(
+            {"input": input_msg},
+            config={"configurable": {"session_id": session_id}},
+        )
+
+        text_buffer = ""
+        with Live("", console=console, refresh_per_second=8, transient=True) as live:
+            for chunk in chunks:
+                text = chunk if isinstance(chunk, str) else chunk.get("output", "")
+                if text:
+                    text_buffer += text
+                    bubble = Panel(Markdown(text_buffer), style="#83cbac", expand=False)
+                    live.update(Align.left(bubble))
+
+        if text_buffer:
+            _print_output(console, text_buffer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CogniWeave CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    demo_cmd = sub.add_parser("demo", help="Run interactive demo")
+    demo_cmd.add_argument("session", nargs="?", default="demo")
+
+    args = parser.parse_args()
+
+    if args.command == "demo":
+        demo(args.session)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cogniweave/quickstart.py
+++ b/src/cogniweave/quickstart.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from langchain_core.messages import MessagesPlaceholder
+
+from cogniweave.core.end_detector import EndDetector
+from cogniweave.core.history_stores import BaseHistoryStore as HistoryStore
+from cogniweave.core.time_splitter import TimeSplitter
+from cogniweave.core.vector_stores import TagsVectorStore
+from cogniweave.llms import OpenAIEmbeddings, StringSingleTurnChat
+from cogniweave.prompts import MessageSegmentsPlaceholder, RichSystemMessagePromptTemplate
+from cogniweave.runnables.end_detector import RunnableWithEndDetector
+from cogniweave.runnables.history_store import RunnableWithHistoryStore
+from cogniweave.runnables.memory_maker import RunnableWithMemoryMaker
+
+DEF_DB = Path("./.cache/history_cache/demo.sqlite")
+DEF_MODEL_CACHE = Path("./.cache/model_cache")
+
+
+def create_embeddings() -> OpenAIEmbeddings:
+    """Create default embeddings instance."""
+    return OpenAIEmbeddings()
+
+
+def create_history_store(db_path: str | Path = DEF_DB) -> HistoryStore:
+    """Create a history store backed by a SQLite database."""
+    return HistoryStore(db_url=f"sqlite:///{Path(db_path)}")
+
+
+def create_vector_store(
+    session_id: str,
+    embeddings: OpenAIEmbeddings,
+    cache_path: str | Path = DEF_MODEL_CACHE,
+) -> TagsVectorStore:
+    """Create a vector store for long term memory."""
+    return TagsVectorStore(
+        folder_path=str(cache_path),
+        index_name=session_id,
+        embeddings=embeddings,
+        allow_dangerous_deserialization=True,
+        auto_save=True,
+    )
+
+
+def create_agent() -> StringSingleTurnChat:
+    """Create the base chat agent."""
+    return StringSingleTurnChat(
+        lang="zh",
+        provider="deepseek",
+        model="deepseek-chat",
+        contexts=[
+            RichSystemMessagePromptTemplate.from_template(
+                [
+                    "你是一个AI助手，你叫CogniWeave，你的任务是回答用户的问题。\n",
+                    MessageSegmentsPlaceholder(variable_name="long_memory"),
+                ]
+            ),
+            MessagesPlaceholder(variable_name="history", optional=True),
+        ],
+    )
+
+
+def build_pipeline(
+    session_id: str = "demo",
+    db_path: str | Path = DEF_DB,
+    model_cache: str | Path = DEF_MODEL_CACHE,
+) -> RunnableWithHistoryStore:
+    """Assemble the runnable pipeline used in the demos."""
+    embeddings = create_embeddings()
+    history_store = create_history_store(db_path)
+    vector_store = create_vector_store(session_id, embeddings, model_cache)
+    agent = create_agent()
+
+    pipeline: RunnableWithHistoryStore = RunnableWithMemoryMaker(
+        agent,
+        history_store=history_store,
+        vector_store=vector_store,
+        input_messages_key="input",
+        history_messages_key="history",
+        short_memory_key="short_memory",
+        long_memory_key="long_memory",
+    )
+    pipeline = RunnableWithEndDetector(
+        pipeline,
+        end_detector=EndDetector(),
+        default={"output": []},
+        history_messages_key="history",
+    )
+    pipeline = RunnableWithHistoryStore(
+        pipeline,
+        history_store=history_store,
+        time_splitter=TimeSplitter(),
+        input_messages_key="input",
+        history_messages_key="history",
+    )
+    return pipeline


### PR DESCRIPTION
## Summary
- add `cogniweave.quickstart` helper with functions for building the demo pipeline
- replace `scripts/quick_demo.py` with `scripts/cli.py`
- document CLI usage and helper functions in README

## Testing
- `ruff check scripts/cli.py src/cogniweave/quickstart.py`
- `ruff check .` *(fails: 8 errors in unrelated files)*
- `pytest -q` *(fails: ModuleNotFoundError for `langchain_core` and `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_6861187066a4832fac469a5b85e28a9d