### PR TITLE
Add prompt file option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ Additional options control where history and vector data are stored:
 python -m cogniweave demo my_session --index my_index --folder /tmp/cache
 ```
 
-The `--index` argument sets the file names for the SQLite database and FAISS index, while `--folder` chooses the directory used to store them.
+You can also load a custom system prompt from a file:
+
+```bash
+python -m cogniweave demo my_session --prompt-file prompt.txt
+```
+
+The `--index` argument sets the file names for the SQLite database and FAISS index, while `--folder` chooses the directory used to store them. The optional `--prompt-file` points to a text file whose content becomes the system prompt for the demo.
 
 ## Quick build
 

--- a/src/cogniweave/cli/__init__.py
+++ b/src/cogniweave/cli/__init__.py
@@ -52,10 +52,14 @@ def demo(
     *,
     index: str = "demo",
     folder: str | Path = DEF_FOLDER_PATH,
+    prompt_file: str | Path | None = None,
 ) -> None:
     """Run the interactive demo."""
 
-    pipeline = build_pipeline(index_name=index, folder_path=folder)
+    prompt: str | None = None
+    if prompt_file:
+        prompt = Path(prompt_file).read_text(encoding="utf-8")
+    pipeline = build_pipeline(index_name=index, folder_path=folder, prompt=prompt)
     history_store = pipeline.history_store
     console = Console()
 
@@ -107,10 +111,20 @@ def main() -> None:
         default=str(DEF_FOLDER_PATH),
         help="Folder used to store cache files",
     )
+    demo_cmd.add_argument(
+        "--prompt-file",
+        help="Path to a file containing the system prompt",
+        default=None,
+    )
 
     args = parser.parse_args()
 
     if args.command == "demo":
-        demo(args.session, index=args.index, folder=Path(args.folder))
+        demo(
+            args.session,
+            index=args.index,
+            folder=Path(args.folder),
+            prompt_file=args.prompt_file,
+        )
     else:
         parser.print_help()


### PR DESCRIPTION
## Summary
- enable passing a prompt file via `--prompt-file`
- update README usage instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_6870be62951c832f9cc33730158345cc