### PR TITLE
Standardize pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,36 +1,41 @@
 [project]
 name = "CogniWeave"
 version = "0.1.0"
-description = ""
+description = "Experimental agent framework built on top of LangChain"
 authors = [
-    {name = "Kotodama",email = "2682064633@qq.com"}
+    { name = "Kotodama", email = "2682064633@qq.com" },
 ]
-license = {text = "Apache License 2.0"}
+license = { text = "Apache License 2.0" }
 readme = "README.md"
 keywords = ["agent"]
 classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
 ]
 requires-python = ">=3.11,<4"
 dependencies = [
     "aiohttp==3.11.14",
+    "aiosqlite",
     "anyio==4.9.0",
     "exceptiongroup==1.2.2",
+    "httpx[socks]",
+    "langchain",
+    "langchain-community==0.3.24",
+    "langchain-core",
+    "langchain-openai",
+    "langgraph",
     "pyahocorasick==2.1.0",
     "pydantic==2.11.5",
     "pygtrie==2.5.0",
     "pypinyin==0.54.0",
+    "python-dotenv",
     "PyYAML==6.0.2",
+    "sqlalchemy>=2.0",
     "structlog==25.2.0",
     "typing_extensions==4.13.2",
-    "langchain",
-    "langchain-core",
-    "langchain-openai",
-    "langchain-community==0.3.24",
-    "sqlalchemy>=2.0",
-    "aiosqlite",
-    "python-dotenv",
-    "httpx[socks]",
-    "langgraph",
 ]
 
 [project.urls]
@@ -39,24 +44,24 @@ Repository = "https://github.com/Inexplicable-YL/CogniWeaveAgent"
 [tool.uv]
 dev-dependencies = [
     # dev
-    "setuptools>=74",
-    "trio>=0.26",
     "exceptiongroup>=1",
+    "setuptools>=74",
     "tomli>=2",
+    "trio>=0.26",
     # lint
-    "ruff>=0.6",
     "mypy>=1",
-    "pylint>=3",
     "pylint-pydantic>=0.3",
+    "pylint>=3",
+    "ruff>=0.6",
     # docs
     "sophia-doc>=0.1",
     "tomlkit>=0.13",
     # test
     "pytest>=8",
     "pytest-asyncio",
+    "pytest-cov>=5",
     "pytest-mock>=3",
     "pytest-xdist>=3",
-    "pytest-cov>=5",
 ]
 
 [tool.ruff]
@@ -137,7 +142,7 @@ reportPrivateUsage = false
 #python_version = "3.11"
 #strict = true
 #disable_error_code = [
-#    "valid-type", 
+#    "valid-type",
 #    "unused-ignore",
 #    "index",
 #    "misc",
@@ -147,7 +152,6 @@ reportPrivateUsage = false
 #[[tool.mypy.overrides]]
 #module = "apscheduler.*"
 #ignore_missing_imports = true
-
 
 [tool.hatch.build]
 packages = ["src/cogniweave"]


### PR DESCRIPTION
## Summary
- tidy and sort sections of `pyproject.toml`
- add a short project description and common classifiers
- alphabetize dependencies and dev dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `langchain_core` and `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_6870cb90703c832f967ca3ecea623fc4